### PR TITLE
fix: harden auth flows and validate project updates

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -85,15 +85,16 @@
 			}
 		},
 		"node_modules/@angular-devkit/core": {
-			"version": "19.2.19",
-			"resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.19.tgz",
-			"integrity": "sha512-JbLL+4IMLMBgjLZlnPG4lYDfz4zGrJ/s6Aoon321NJKuw1Kb1k5KpFu9dUY0BqLIe8xPQ2UJBpI+xXdK5MXMHQ==",
+			"version": "19.2.24",
+			"resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.24.tgz",
+			"integrity": "sha512-Kd49warf6U/EyWe5BszF/eebN3zQ3bk7tgfEljAw8q/rX95UUtriJubWvp6pgzHfzBA4jwq8f+QiNZB8eBEXPA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"ajv": "8.17.1",
+				"ajv": "8.18.0",
 				"ajv-formats": "3.0.1",
 				"jsonc-parser": "3.3.1",
-				"picomatch": "4.0.2",
+				"picomatch": "4.0.4",
 				"rxjs": "7.8.1",
 				"source-map": "0.7.4"
 			},
@@ -112,10 +113,11 @@
 			}
 		},
 		"node_modules/@angular-devkit/core/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -131,15 +133,17 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@angular-devkit/schematics": {
-			"version": "19.2.19",
-			"resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.19.tgz",
-			"integrity": "sha512-J4Jarr0SohdrHcb40gTL4wGPCQ952IMWF1G/MSAQfBAPvA9ZKApYhpxcY7PmehVePve+ujpus1dGsJ7dPxz8Kg==",
+			"version": "19.2.24",
+			"resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.24.tgz",
+			"integrity": "sha512-lnw+ZM1Io+cJAkReC0NPDjqObL8NtKzKIkdgEEKC8CUmkhurYhedbicN8Y8NYHgG1uLd2GozW3+/QqPRZaN+Lw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@angular-devkit/core": "19.2.19",
+				"@angular-devkit/core": "19.2.24",
 				"jsonc-parser": "3.3.1",
 				"magic-string": "0.30.17",
 				"ora": "5.4.1",
@@ -152,13 +156,14 @@
 			}
 		},
 		"node_modules/@angular-devkit/schematics-cli": {
-			"version": "19.2.19",
-			"resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-19.2.19.tgz",
-			"integrity": "sha512-7q9UY6HK6sccL9F3cqGRUwKhM7b/XfD2YcVaZ2WD7VMaRlRm85v6mRjSrfKIAwxcQU0UK27kMc79NIIqaHjzxA==",
+			"version": "19.2.24",
+			"resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-19.2.24.tgz",
+			"integrity": "sha512-bsStZQG67J1HBqTmWxtIcobvgrn32L4UOdL7hGyOru5VxDWPNA8pRnDYavT3hnJeBkJYPoQIw8u7Dm0ecoQprw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@angular-devkit/core": "19.2.19",
-				"@angular-devkit/schematics": "19.2.19",
+				"@angular-devkit/core": "19.2.24",
+				"@angular-devkit/schematics": "19.2.24",
 				"@inquirer/prompts": "7.3.2",
 				"ansi-colors": "4.1.3",
 				"symbol-observable": "4.0.0",
@@ -178,6 +183,7 @@
 			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.3.2.tgz",
 			"integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@inquirer/checkbox": "^4.1.2",
 				"@inquirer/confirm": "^5.1.6",
@@ -682,6 +688,16 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/@colors/colors": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -1078,22 +1094,6 @@
 				}
 			}
 		},
-		"node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-			"integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-			"dev": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
 		"node_modules/@inquirer/figures": {
 			"version": "1.0.15",
 			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
@@ -1286,27 +1286,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.4.0.tgz",
 			"integrity": "sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ=="
-		},
-		"node_modules/@isaacs/balanced-match": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-			"dev": true,
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@isaacs/brace-expansion": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-			"dev": true,
-			"dependencies": {
-				"@isaacs/balanced-match": "^4.0.1"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			}
 		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
@@ -1854,10 +1833,11 @@
 			}
 		},
 		"node_modules/@jridgewell/source-map": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-			"integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+			"version": "0.3.11",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25"
@@ -2181,14 +2161,15 @@
 			}
 		},
 		"node_modules/@nestjs/cli": {
-			"version": "11.0.12",
-			"resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.12.tgz",
-			"integrity": "sha512-V3fD1xESlFcJ1xpwOtUhn0edLvIa76Sx8mkvdR1s8cM4c/rZO+yGmXP30ZQwPfIJPTgBvsw93F/i+87eV96wcQ==",
+			"version": "11.0.19",
+			"resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.19.tgz",
+			"integrity": "sha512-9htODqTVVNH4lJqyeIotsAgfeaYngDi020cVCd6JhJRKuOT83c/t4JDSky6+xr0lhHyNTNMgZmulxqcMNZFfrw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@angular-devkit/core": "19.2.19",
-				"@angular-devkit/schematics": "19.2.19",
-				"@angular-devkit/schematics-cli": "19.2.19",
+				"@angular-devkit/core": "19.2.24",
+				"@angular-devkit/schematics": "19.2.24",
+				"@angular-devkit/schematics-cli": "19.2.24",
 				"@inquirer/prompts": "7.10.1",
 				"@nestjs/schematics": "^11.0.1",
 				"ansis": "4.2.0",
@@ -2196,13 +2177,13 @@
 				"cli-table3": "0.6.5",
 				"commander": "4.1.1",
 				"fork-ts-checker-webpack-plugin": "9.1.0",
-				"glob": "12.0.0",
+				"glob": "13.0.6",
 				"node-emoji": "1.11.0",
 				"ora": "5.4.1",
 				"tsconfig-paths": "4.2.0",
 				"tsconfig-paths-webpack-plugin": "4.2.0",
 				"typescript": "5.9.3",
-				"webpack": "5.100.2",
+				"webpack": "5.106.0",
 				"webpack-node-externals": "3.0.0"
 			},
 			"bin": {
@@ -2212,7 +2193,7 @@
 				"node": ">= 20.11"
 			},
 			"peerDependencies": {
-				"@swc/cli": "^0.1.62 || ^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0",
+				"@swc/cli": "^0.1.62 || ^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0",
 				"@swc/core": "^1.3.62"
 			},
 			"peerDependenciesMeta": {
@@ -2238,13 +2219,14 @@
 			}
 		},
 		"node_modules/@nestjs/common": {
-			"version": "11.1.6",
-			"resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.6.tgz",
-			"integrity": "sha512-krKwLLcFmeuKDqngG2N/RuZHCs2ycsKcxWIDgcm7i1lf3sQ0iG03ci+DsP/r3FcT/eJDFsIHnKtNta2LIi7PzQ==",
+			"version": "11.1.19",
+			"resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.19.tgz",
+			"integrity": "sha512-qeiTt2tv+e5QyDKqG8HlVZb2wx64FEaSGFJouqTSRs+kG44iTfl3xlz1XqVped+rihx4hmjWgL5gkhtdK3E6+Q==",
+			"license": "MIT",
 			"dependencies": {
-				"file-type": "21.0.0",
+				"file-type": "21.3.4",
 				"iterare": "1.2.1",
-				"load-esm": "1.0.2",
+				"load-esm": "1.0.3",
 				"tslib": "2.8.1",
 				"uid": "2.0.2"
 			},
@@ -2267,29 +2249,14 @@
 				}
 			}
 		},
-		"node_modules/@nestjs/common/node_modules/file-type": {
-			"version": "21.0.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.0.0.tgz",
-			"integrity": "sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==",
+		"node_modules/@nestjs/common/node_modules/@tokenizer/inflate": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"license": "MIT",
 			"dependencies": {
-				"@tokenizer/inflate": "^0.2.7",
-				"strtok3": "^10.2.2",
-				"token-types": "^6.0.0",
-				"uint8array-extras": "^1.4.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
-			}
-		},
-		"node_modules/@nestjs/common/node_modules/strtok3": {
-			"version": "10.3.4",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
-			"dependencies": {
-				"@tokenizer/token": "^0.3.0"
+				"debug": "^4.4.3",
+				"token-types": "^6.1.1"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2299,16 +2266,35 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
+		"node_modules/@nestjs/common/node_modules/file-type": {
+			"version": "21.3.4",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+			"integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
 		"node_modules/@nestjs/core": {
-			"version": "11.0.8",
-			"resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.0.8.tgz",
-			"integrity": "sha512-GQLLdZnjZOmV4Q+TzQ8YuHvEYOneRhzsDbSJRkKdFFAVuoVh+q1nWZy+bZNeTxdWZFGL2Rve70X5jc4MoSXJqQ==",
+			"version": "11.1.19",
+			"resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.19.tgz",
+			"integrity": "sha512-6nJkWa2efrYi+XlU686J9y5L7OvxpLVjT0T/sxRKE7Jvpffiihelup4WSvLvRhdHDjj/5SuoWEwqReXAaaeHmw==",
 			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
 				"@nuxt/opencollective": "0.4.1",
 				"fast-safe-stringify": "2.1.1",
 				"iterare": "1.2.1",
-				"path-to-regexp": "8.2.0",
+				"path-to-regexp": "8.4.2",
 				"tslib": "2.8.1",
 				"uid": "2.0.2"
 			},
@@ -2353,13 +2339,14 @@
 			}
 		},
 		"node_modules/@nestjs/mapped-types": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
-			"integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+			"integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+			"license": "MIT",
 			"peerDependencies": {
 				"@nestjs/common": "^10.0.0 || ^11.0.0",
 				"class-transformer": "^0.4.0 || ^0.5.0",
-				"class-validator": "^0.13.0 || ^0.14.0",
+				"class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
 				"reflect-metadata": "^0.1.12 || ^0.2.0"
 			},
 			"peerDependenciesMeta": {
@@ -2372,14 +2359,15 @@
 			}
 		},
 		"node_modules/@nestjs/platform-express": {
-			"version": "11.0.8",
-			"resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.0.8.tgz",
-			"integrity": "sha512-Ru7seOYYglKNGQFzNALE5ilLqkdtX/ge6AJDKLMt+WI7iElZ7lXjT40fE3+HVUiZODunmeKQ7jVxcQyZwLafVA==",
+			"version": "11.1.19",
+			"resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.19.tgz",
+			"integrity": "sha512-Vpdv8jyCQdThfoTx+UTn+DRYr6H6X02YUqcpZ3qP6G3ZUwtVp7eS+hoQPGd4UuCnlnFG8Wqr2J9bGEzQdi1rIg==",
+			"license": "MIT",
 			"dependencies": {
-				"cors": "2.8.5",
-				"express": "5.0.1",
-				"multer": "1.4.5-lts.1",
-				"path-to-regexp": "8.2.0",
+				"cors": "2.8.6",
+				"express": "5.2.1",
+				"multer": "2.1.1",
+				"path-to-regexp": "8.4.2",
 				"tslib": "2.8.1"
 			},
 			"funding": {
@@ -2392,14 +2380,15 @@
 			}
 		},
 		"node_modules/@nestjs/schematics": {
-			"version": "11.0.9",
-			"resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.9.tgz",
-			"integrity": "sha512-0NfPbPlEaGwIT8/TCThxLzrlz3yzDNkfRNpbL7FiplKq3w4qXpJg0JYwqgMEJnLQZm3L/L/5XjoyfJHUO3qX9g==",
+			"version": "11.0.10",
+			"resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.10.tgz",
+			"integrity": "sha512-q9lr0wGwgBHLarD4uno3XiW4JX60WPlg2VTgbqPHl/6bT4u1IEEzj+q9Tad3bVnqL5mlDF3vrZ2tj+x13CJpmw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@angular-devkit/core": "19.2.17",
-				"@angular-devkit/schematics": "19.2.17",
-				"comment-json": "4.4.1",
+				"@angular-devkit/core": "19.2.23",
+				"@angular-devkit/schematics": "19.2.23",
+				"comment-json": "4.6.2",
 				"jsonc-parser": "3.3.1",
 				"pluralize": "8.0.0"
 			},
@@ -2408,15 +2397,16 @@
 			}
 		},
 		"node_modules/@nestjs/schematics/node_modules/@angular-devkit/core": {
-			"version": "19.2.17",
-			"resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.17.tgz",
-			"integrity": "sha512-Ah008x2RJkd0F+NLKqIpA34/vUGwjlprRCkvddjDopAWRzYn6xCkz1Tqwuhn0nR1Dy47wTLKYD999TYl5ONOAQ==",
+			"version": "19.2.23",
+			"resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.23.tgz",
+			"integrity": "sha512-RazHPQkUEsNU/OZ75w9UeHxGFMthRiuAW2B/uA7eXExBj/1meHrrBfoCA56ujW2GUxVjRtSrMjylKh4R4meiYA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"ajv": "8.17.1",
+				"ajv": "8.18.0",
 				"ajv-formats": "3.0.1",
 				"jsonc-parser": "3.3.1",
-				"picomatch": "4.0.2",
+				"picomatch": "4.0.4",
 				"rxjs": "7.8.1",
 				"source-map": "0.7.4"
 			},
@@ -2435,12 +2425,13 @@
 			}
 		},
 		"node_modules/@nestjs/schematics/node_modules/@angular-devkit/schematics": {
-			"version": "19.2.17",
-			"resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.17.tgz",
-			"integrity": "sha512-ADfbaBsrG8mBF6Mfs+crKA/2ykB8AJI50Cv9tKmZfwcUcyAdmTr+vVvhsBCfvUAEokigSsgqgpYxfkJVxhJYeg==",
+			"version": "19.2.23",
+			"resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.23.tgz",
+			"integrity": "sha512-Jzs7YM4X6azmHU7Mw5tQSPMuvaqYS8SLnZOJbtiXCy1JyuW9bm/WBBecNHMiuZ8LHXKhvQ6AVX1tKrzF6uiDmw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@angular-devkit/core": "19.2.17",
+				"@angular-devkit/core": "19.2.23",
 				"jsonc-parser": "3.3.1",
 				"magic-string": "0.30.17",
 				"ora": "5.4.1",
@@ -2453,10 +2444,11 @@
 			}
 		},
 		"node_modules/@nestjs/schematics/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -2472,7 +2464,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@nestjs/sequelize": {
 			"version": "11.0.1",
@@ -2488,19 +2481,20 @@
 			}
 		},
 		"node_modules/@nestjs/swagger": {
-			"version": "11.2.3",
-			"resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.3.tgz",
-			"integrity": "sha512-a0xFfjeqk69uHIUpP8u0ryn4cKuHdra2Ug96L858i0N200Hxho+n3j+TlQXyOF4EstLSGjTfxI1Xb2E1lUxeNg==",
+			"version": "11.2.7",
+			"resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.7.tgz",
+			"integrity": "sha512-+e1KWSyZMAQeyZ8nbQSvm3fhzqdxxBNQENvpjO2dVyD7KJmLTTQyXpRb1nM5O04oFdDTUtG3SHMl4+e+zgCK2A==",
+			"license": "MIT",
 			"dependencies": {
 				"@microsoft/tsdoc": "0.16.0",
-				"@nestjs/mapped-types": "2.1.0",
+				"@nestjs/mapped-types": "2.1.1",
 				"js-yaml": "4.1.1",
-				"lodash": "4.17.21",
-				"path-to-regexp": "8.3.0",
-				"swagger-ui-dist": "5.30.2"
+				"lodash": "4.18.1",
+				"path-to-regexp": "8.4.2",
+				"swagger-ui-dist": "5.32.2"
 			},
 			"peerDependencies": {
-				"@fastify/static": "^8.0.0",
+				"@fastify/static": "^8.0.0 || ^9.0.0",
 				"@nestjs/common": "^11.0.1",
 				"@nestjs/core": "^11.0.1",
 				"class-transformer": "*",
@@ -2517,15 +2511,6 @@
 				"class-validator": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-			"integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/@nestjs/testing": {
@@ -2738,13 +2723,8 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
 			"integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
-			"hasInstallScript": true
-		},
-		"node_modules/@sec-ant/readable-stream": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-			"integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-			"dev": true
+			"hasInstallScript": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.8",
@@ -2757,6 +2737,7 @@
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
 			"integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.16"
 			},
@@ -2827,10 +2808,11 @@
 			}
 		},
 		"node_modules/@swc/cli/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -2845,12 +2827,13 @@
 			}
 		},
 		"node_modules/@swc/cli/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -3077,6 +3060,7 @@
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
 			"integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"defer-to-connect": "^2.0.1"
 			},
@@ -3088,6 +3072,8 @@
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
 			"integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.0",
 				"fflate": "^0.8.2",
@@ -3104,7 +3090,8 @@
 		"node_modules/@tokenizer/token": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"license": "MIT"
 		},
 		"node_modules/@tsconfig/node10": {
 			"version": "1.0.11",
@@ -3315,10 +3302,11 @@
 			}
 		},
 		"node_modules/@types/http-cache-semantics": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-			"dev": true
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/http-errors": {
 			"version": "2.0.4",
@@ -3638,21 +3626,23 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -3848,22 +3838,24 @@
 			}
 		},
 		"node_modules/@xhmikosr/archive-type": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@xhmikosr/archive-type/-/archive-type-7.0.0.tgz",
-			"integrity": "sha512-sIm84ZneCOJuiy3PpWR5bxkx3HaNt1pqaN+vncUBZIlPZCq8ASZH+hBVdu5H8znR7qYC6sKwx+ie2Q7qztJTxA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@xhmikosr/archive-type/-/archive-type-7.1.0.tgz",
+			"integrity": "sha512-xZEpnGplg1sNPyEgFh0zbHxqlw5dtYg6viplmWSxUj12+QjU9SKu3U/2G73a15pEjLaOqTefNSZ1fOPUOT4Xgg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"file-type": "^19.0.0"
+				"file-type": "^20.5.0"
 			},
 			"engines": {
-				"node": "^14.14.0 || >=16.0.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@xhmikosr/bin-check": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@xhmikosr/bin-check/-/bin-check-7.0.3.tgz",
-			"integrity": "sha512-4UnCLCs8DB+itHJVkqFp9Zjg+w/205/J2j2wNBsCEAm/BuBmtua2hhUOdAMQE47b1c7P9Xmddj0p+X1XVsfHsA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@xhmikosr/bin-check/-/bin-check-7.1.0.tgz",
+			"integrity": "sha512-y1O95J4mnl+6MpVmKfMYXec17hMEwE/yeCglFNdx+QvLLtP0yN4rSYcbkXnth+lElBuKKek2NbvOfOGPpUXCvw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"execa": "^5.1.1",
 				"isexe": "^2.0.0"
@@ -3873,13 +3865,14 @@
 			}
 		},
 		"node_modules/@xhmikosr/bin-wrapper": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@xhmikosr/bin-wrapper/-/bin-wrapper-13.0.5.tgz",
-			"integrity": "sha512-DT2SAuHDeOw0G5bs7wZbQTbf4hd8pJ14tO0i4cWhRkIJfgRdKmMfkDilpaJ8uZyPA0NVRwasCNAmMJcWA67osw==",
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/@xhmikosr/bin-wrapper/-/bin-wrapper-13.2.0.tgz",
+			"integrity": "sha512-t9U9X0sDPRGDk5TGx4dv5xiOvniVJpXnfTuynVKwHgtib95NYEw4MkZdJqhoSiz820D9m0o6PCqOPMXz0N9fIw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@xhmikosr/bin-check": "^7.0.3",
-				"@xhmikosr/downloader": "^15.0.1",
+				"@xhmikosr/bin-check": "^7.1.0",
+				"@xhmikosr/downloader": "^15.2.0",
 				"@xhmikosr/os-filter-obj": "^3.0.0",
 				"bin-version-check": "^5.1.0"
 			},
@@ -3888,17 +3881,17 @@
 			}
 		},
 		"node_modules/@xhmikosr/decompress": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/@xhmikosr/decompress/-/decompress-10.0.1.tgz",
-			"integrity": "sha512-6uHnEEt5jv9ro0CDzqWlFgPycdE+H+kbJnwyxgZregIMLQ7unQSCNVsYG255FoqU8cP46DyggI7F7LohzEl8Ag==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/@xhmikosr/decompress/-/decompress-10.2.0.tgz",
+			"integrity": "sha512-MmDBvu0+GmADyQWHolcZuIWffgfnuTo4xpr2I/Qw5Ox0gt+e1Be7oYqJM4te5ylL6mzlcoicnHVDvP27zft8tg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@xhmikosr/decompress-tar": "^8.0.1",
-				"@xhmikosr/decompress-tarbz2": "^8.0.1",
-				"@xhmikosr/decompress-targz": "^8.0.1",
-				"@xhmikosr/decompress-unzip": "^7.0.0",
+				"@xhmikosr/decompress-tar": "^8.1.0",
+				"@xhmikosr/decompress-tarbz2": "^8.1.0",
+				"@xhmikosr/decompress-targz": "^8.1.0",
+				"@xhmikosr/decompress-unzip": "^7.1.0",
 				"graceful-fs": "^4.2.11",
-				"make-dir": "^4.0.0",
 				"strip-dirs": "^3.0.0"
 			},
 			"engines": {
@@ -3906,12 +3899,13 @@
 			}
 		},
 		"node_modules/@xhmikosr/decompress-tar": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tar/-/decompress-tar-8.0.1.tgz",
-			"integrity": "sha512-dpEgs0cQKJ2xpIaGSO0hrzz3Kt8TQHYdizHsgDtLorWajuHJqxzot9Hbi0huRxJuAGG2qiHSQkwyvHHQtlE+fg==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tar/-/decompress-tar-8.1.0.tgz",
+			"integrity": "sha512-m0q8x6lwxenh1CrsTby0Jrjq4vzW/QU1OLhTHMQLEdHpmjR1lgahGz++seZI0bXF3XcZw3U3xHfqZSz+JPP2Gg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"file-type": "^19.0.0",
+				"file-type": "^20.5.0",
 				"is-stream": "^2.0.1",
 				"tar-stream": "^3.1.7"
 			},
@@ -3920,13 +3914,14 @@
 			}
 		},
 		"node_modules/@xhmikosr/decompress-tarbz2": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tarbz2/-/decompress-tarbz2-8.0.2.tgz",
-			"integrity": "sha512-p5A2r/AVynTQSsF34Pig6olt9CvRj6J5ikIhzUd3b57pUXyFDGtmBstcw+xXza0QFUh93zJsmY3zGeNDlR2AQQ==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tarbz2/-/decompress-tarbz2-8.1.0.tgz",
+			"integrity": "sha512-aCLfr3A/FWZnOu5eqnJfme1Z1aumai/WRw55pCvBP+hCGnTFrcpsuiaVN5zmWTR53a8umxncY2JuYsD42QQEbw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@xhmikosr/decompress-tar": "^8.0.1",
-				"file-type": "^19.6.0",
+				"file-type": "^20.5.0",
 				"is-stream": "^2.0.1",
 				"seek-bzip": "^2.0.0",
 				"unbzip2-stream": "^1.4.3"
@@ -3936,13 +3931,14 @@
 			}
 		},
 		"node_modules/@xhmikosr/decompress-targz": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@xhmikosr/decompress-targz/-/decompress-targz-8.0.1.tgz",
-			"integrity": "sha512-mvy5AIDIZjQ2IagMI/wvauEiSNHhu/g65qpdM4EVoYHUJBAmkQWqcPJa8Xzi1aKVTmOA5xLJeDk7dqSjlHq8Mg==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@xhmikosr/decompress-targz/-/decompress-targz-8.1.0.tgz",
+			"integrity": "sha512-fhClQ2wTmzxzdz2OhSQNo9ExefrAagw93qaG1YggoIz/QpI7atSRa7eOHv4JZkpHWs91XNn8Hry3CwUlBQhfPA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@xhmikosr/decompress-tar": "^8.0.1",
-				"file-type": "^19.0.0",
+				"file-type": "^20.5.0",
 				"is-stream": "^2.0.1"
 			},
 			"engines": {
@@ -3950,12 +3946,13 @@
 			}
 		},
 		"node_modules/@xhmikosr/decompress-unzip": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@xhmikosr/decompress-unzip/-/decompress-unzip-7.0.0.tgz",
-			"integrity": "sha512-GQMpzIpWTsNr6UZbISawsGI0hJ4KA/mz5nFq+cEoPs12UybAqZWKbyIaZZyLbJebKl5FkLpsGBkrplJdjvUoSQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@xhmikosr/decompress-unzip/-/decompress-unzip-7.1.0.tgz",
+			"integrity": "sha512-oqTYAcObqTlg8owulxFTqiaJkfv2SHsxxxz9Wg4krJAHVzGWlZsU8tAB30R6ow+aHrfv4Kub6WQ8u04NWVPUpA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"file-type": "^19.0.0",
+				"file-type": "^20.5.0",
 				"get-stream": "^6.0.1",
 				"yauzl": "^3.1.2"
 			},
@@ -3964,17 +3961,18 @@
 			}
 		},
 		"node_modules/@xhmikosr/downloader": {
-			"version": "15.0.1",
-			"resolved": "https://registry.npmjs.org/@xhmikosr/downloader/-/downloader-15.0.1.tgz",
-			"integrity": "sha512-fiuFHf3Dt6pkX8HQrVBsK0uXtkgkVlhrZEh8b7VgoDqFf+zrgFBPyrwCqE/3nDwn3hLeNz+BsrS7q3mu13Lp1g==",
+			"version": "15.2.0",
+			"resolved": "https://registry.npmjs.org/@xhmikosr/downloader/-/downloader-15.2.0.tgz",
+			"integrity": "sha512-lAqbig3uRGTt0sHNIM4vUG9HoM+mRl8K28WuYxyXLCUT6pyzl4Y4i0LZ3jMEsCYZ6zjPZbO9XkG91OSTd4si7g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@xhmikosr/archive-type": "^7.0.0",
-				"@xhmikosr/decompress": "^10.0.1",
+				"@xhmikosr/archive-type": "^7.1.0",
+				"@xhmikosr/decompress": "^10.2.0",
 				"content-disposition": "^0.5.4",
-				"defaults": "^3.0.0",
+				"defaults": "^2.0.2",
 				"ext-name": "^5.0.0",
-				"file-type": "^19.0.0",
+				"file-type": "^20.5.0",
 				"filenamify": "^6.0.0",
 				"get-stream": "^6.0.1",
 				"got": "^13.0.0"
@@ -4019,6 +4017,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
 			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
 			"dependencies": {
 				"mime-types": "^3.0.0",
 				"negotiator": "^1.0.0"
@@ -4028,10 +4027,11 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4081,10 +4081,11 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -4101,6 +4102,7 @@
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
 			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.0.0"
 			},
@@ -4114,10 +4116,11 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -4133,7 +4136,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ajv-keywords": {
 			"version": "3.5.2",
@@ -4161,6 +4165,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
 			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -4228,10 +4233,11 @@
 			}
 		},
 		"node_modules/anymatch/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -4242,7 +4248,8 @@
 		"node_modules/append-field": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
-			"integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
+			"integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+			"license": "MIT"
 		},
 		"node_modules/arch": {
 			"version": "3.0.0",
@@ -4289,16 +4296,12 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
-		"node_modules/array-flatten": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-			"integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-		},
 		"node_modules/array-timsort": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
 			"integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/asap": {
 			"version": "2.0.6",
@@ -4326,10 +4329,19 @@
 			}
 		},
 		"node_modules/b4a": {
-			"version": "1.6.7",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-			"integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
-			"dev": true
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+			"integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/babel-jest": {
 			"version": "29.7.0",
@@ -4456,11 +4468,101 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"node_modules/bare-events": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
-			"integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+			"integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
 			"dev": true,
-			"optional": true
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"bare-abort-controller": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-fs": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.0.tgz",
+			"integrity": "sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.5.4",
+				"bare-path": "^3.0.0",
+				"bare-stream": "^2.6.4",
+				"bare-url": "^2.2.2",
+				"fast-fifo": "^1.3.2"
+			},
+			"engines": {
+				"bare": ">=1.16.0"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-os": {
+			"version": "3.8.7",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+			"integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"bare": ">=1.14.0"
+			}
+		},
+		"node_modules/bare-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+			"integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-os": "^3.0.1"
+			}
+		},
+		"node_modules/bare-stream": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+			"integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"streamx": "^2.25.0",
+				"teex": "^1.0.1"
+			},
+			"peerDependencies": {
+				"bare-abort-controller": "*",
+				"bare-buffer": "*",
+				"bare-events": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				},
+				"bare-buffer": {
+					"optional": true
+				},
+				"bare-events": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-url": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+			"integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-path": "^3.0.0"
+			}
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -4480,6 +4582,19 @@
 					"url": "https://feross.org/support"
 				}
 			]
+		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.19",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+			"integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
 		},
 		"node_modules/bignumber.js": {
 			"version": "9.3.1",
@@ -4539,95 +4654,33 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
-		"node_modules/bl/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 		},
 		"node_modules/body-parser": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.0.2.tgz",
-			"integrity": "sha512-SNMk0OONlQ01uk8EPeiBvTW7W4ovpL5b1O3t1sjpPgfxOQ6BqQJ6XjxinDPR79Z6HdcD5zBBwr5ssiTlgdNztQ==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"license": "MIT",
 			"dependencies": {
-				"bytes": "3.1.2",
-				"content-type": "~1.0.5",
-				"debug": "3.1.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.5.2",
-				"on-finished": "2.4.1",
-				"qs": "6.13.0",
-				"raw-body": "^3.0.0",
-				"type-is": "~1.6.18"
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/body-parser/node_modules/debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/body-parser/node_modules/media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/body-parser/node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/body-parser/node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dependencies": {
-				"mime-db": "1.52.0"
 			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/body-parser/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-		},
-		"node_modules/body-parser/node_modules/type-is": {
-			"version": "1.6.18",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-			"dependencies": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
-			},
-			"engines": {
-				"node": ">= 0.6"
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/brace-expansion": {
@@ -4652,9 +4705,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.24.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"dev": true,
 			"funding": [
 				{
@@ -4670,11 +4723,13 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001688",
-				"electron-to-chromium": "^1.5.73",
-				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.1"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -4733,6 +4788,7 @@
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
@@ -4769,6 +4825,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
 			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -4778,6 +4835,7 @@
 			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
 			"integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.16"
 			}
@@ -4787,6 +4845,7 @@
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
 			"integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/http-cache-semantics": "^4.0.2",
 				"get-stream": "^6.0.1",
@@ -4846,9 +4905,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001699",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
-			"integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
+			"version": "1.0.30001788",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+			"integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4863,7 +4922,8 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
-			]
+			],
+			"license": "CC-BY-4.0"
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -5183,13 +5243,13 @@
 			}
 		},
 		"node_modules/comment-json": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.4.1.tgz",
-			"integrity": "sha512-r1To31BQD5060QdkC+Iheai7gHwoSZobzunqkf2/kQ6xIAfJyrKNAFUwdKvkK7Qgu7pVTKQEa7ok7Ed3ycAJgg==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.6.2.tgz",
+			"integrity": "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"array-timsort": "^1.0.3",
-				"core-util-is": "^1.0.3",
 				"esprima": "^4.0.1"
 			},
 			"engines": {
@@ -5211,16 +5271,17 @@
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
 		"node_modules/concat-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+			"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
 			"engines": [
-				"node >= 0.8"
+				"node >= 6.0"
 			],
+			"license": "MIT",
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
+				"readable-stream": "^3.0.2",
 				"typedarray": "^0.0.6"
 			}
 		},
@@ -5258,6 +5319,7 @@
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
 			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "5.2.1"
 			},
@@ -5269,6 +5331,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
 			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -5280,9 +5343,10 @@
 			"dev": true
 		},
 		"node_modules/cookie": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-			"integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -5300,15 +5364,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/cookie-parser/node_modules/cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/cookie-parser/node_modules/cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -5319,6 +5374,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
 			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.6.0"
 			}
@@ -5329,21 +5385,21 @@
 			"integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
 			"dev": true
 		},
-		"node_modules/core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-		},
 		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
 			"dependencies": {
 				"object-assign": "^4",
 				"vary": "^1"
 			},
 			"engines": {
 				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/cosmiconfig": {
@@ -5421,9 +5477,10 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -5441,6 +5498,7 @@
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
 			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^3.1.0"
 			},
@@ -5456,6 +5514,7 @@
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
 			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -5493,12 +5552,13 @@
 			}
 		},
 		"node_modules/defaults": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-3.0.0.tgz",
-			"integrity": "sha512-RsqXDEAALjfRTro+IFNKpcPCt0/Cy2FqHSIlnomiJp9YGadpQnrtbRpSgN2+np21qHcIKiva4fiOQGjS9/qR/A==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-2.0.2.tgz",
+			"integrity": "sha512-cuIw0PImdp76AOfgkjbW4VhQODRmNNcKR73vdCH5cLd/ifj7aamfoXvYgfGkEAjNJZ3ozMIy9Gu2LutUkGEPbA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5509,6 +5569,7 @@
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
 			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
@@ -5539,15 +5600,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/destroy": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
 		"node_modules/detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -5568,10 +5620,11 @@
 			}
 		},
 		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
@@ -5597,9 +5650,11 @@
 			}
 		},
 		"node_modules/dottie": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.6.tgz",
-			"integrity": "sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA=="
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.7.tgz",
+			"integrity": "sha512-7lAK2A0b3zZr3UC5aE69CPdCFR4RHW1o2Dr74TqFykxkUCBXSRJum/yPc7g8zRHJqWKomPLHwFLLoUnn8PXXRg==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"license": "MIT"
 		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
@@ -5629,13 +5684,14 @@
 			}
 		},
 		"node_modules/editorconfig": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
-			"integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+			"integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+			"license": "MIT",
 			"dependencies": {
 				"@one-ini/wasm": "0.1.1",
 				"commander": "^10.0.0",
-				"minimatch": "9.0.1",
+				"minimatch": "^9.0.1",
 				"semver": "^7.5.3"
 			},
 			"bin": {
@@ -5646,9 +5702,10 @@
 			}
 		},
 		"node_modules/editorconfig/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -5662,11 +5719,12 @@
 			}
 		},
 		"node_modules/editorconfig/node_modules/minimatch": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-			"integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -5678,7 +5736,8 @@
 		"node_modules/ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"license": "MIT"
 		},
 		"node_modules/ejs": {
 			"version": "3.1.10",
@@ -5696,10 +5755,11 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.96",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.96.tgz",
-			"integrity": "sha512-8AJUW6dh75Fm/ny8+kZKJzI1pgoE8bKLZlzDU2W1ENd+DXKJrx7I7l9hb8UWR4ojlnb5OlixMt00QWiYJoVw1w==",
-			"dev": true
+			"version": "1.5.336",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
+			"integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/emittery": {
 			"version": "0.13.1",
@@ -5728,18 +5788,20 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
 			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-			"integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+			"version": "5.20.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+			"integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
+				"tapable": "^2.3.0"
 			},
 			"engines": {
 				"node": ">=10.13.0"
@@ -5771,10 +5833,11 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-			"integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
-			"dev": true
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -5813,7 +5876,8 @@
 		"node_modules/escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -6032,6 +6096,7 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -6043,6 +6108,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.8.x"
+			}
+		},
+		"node_modules/events-universal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+			"integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.7.0"
 			}
 		},
 		"node_modules/execa": {
@@ -6100,45 +6175,46 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-5.0.1.tgz",
-			"integrity": "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
 			"dependencies": {
 				"accepts": "^2.0.0",
-				"body-parser": "^2.0.1",
+				"body-parser": "^2.2.1",
 				"content-disposition": "^1.0.0",
-				"content-type": "~1.0.4",
-				"cookie": "0.7.1",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
 				"cookie-signature": "^1.2.1",
-				"debug": "4.3.6",
-				"depd": "2.0.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "^2.0.0",
-				"fresh": "2.0.0",
-				"http-errors": "2.0.0",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
 				"merge-descriptors": "^2.0.0",
-				"methods": "~1.1.2",
 				"mime-types": "^3.0.0",
-				"on-finished": "2.4.1",
-				"once": "1.4.0",
-				"parseurl": "~1.3.3",
-				"proxy-addr": "~2.0.7",
-				"qs": "6.13.0",
-				"range-parser": "~1.2.1",
-				"router": "^2.0.0",
-				"safe-buffer": "5.2.1",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
 				"send": "^1.1.0",
-				"serve-static": "^2.1.0",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"type-is": "^2.0.0",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
 			},
 			"engines": {
 				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/express-session": {
@@ -6157,15 +6233,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/express-session/node_modules/cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/express-session/node_modules/cookie-signature": {
@@ -6190,42 +6257,24 @@
 			"license": "MIT"
 		},
 		"node_modules/express/node_modules/content-disposition": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-			"integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-			"dependencies": {
-				"safe-buffer": "5.2.1"
-			},
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"license": "MIT",
 			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/express/node_modules/debug": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-			"dependencies": {
-				"ms": "2.1.2"
+				"node": ">=18"
 			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
-		},
-		"node_modules/express/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/ext-list": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
 			"integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"mime-db": "^1.28.0"
 			},
@@ -6238,6 +6287,7 @@
 			"resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
 			"integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ext-list": "^2.0.0",
 				"sort-keys-length": "^1.0.0"
@@ -6267,7 +6317,8 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
 			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
@@ -6379,7 +6430,9 @@
 		"node_modules/fflate": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
@@ -6394,49 +6447,22 @@
 			}
 		},
 		"node_modules/file-type": {
-			"version": "19.6.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
-			"integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
+			"integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"get-stream": "^9.0.1",
-				"strtok3": "^9.0.1",
+				"@tokenizer/inflate": "^0.2.6",
+				"strtok3": "^10.2.0",
 				"token-types": "^6.0.0",
-				"uint8array-extras": "^1.3.0"
+				"uint8array-extras": "^1.4.0"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
-			}
-		},
-		"node_modules/file-type/node_modules/get-stream": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-			"dev": true,
-			"dependencies": {
-				"@sec-ant/readable-stream": "^0.4.1",
-				"is-stream": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/file-type/node_modules/is-stream": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-			"dev": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/filelist": {
@@ -6449,19 +6475,21 @@
 			}
 		},
 		"node_modules/filelist/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/filelist/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -6474,6 +6502,7 @@
 			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
 			"integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
@@ -6486,6 +6515,7 @@
 			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
 			"integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"filename-reserved-regex": "^3.0.0"
 			},
@@ -6509,42 +6539,25 @@
 			}
 		},
 		"node_modules/finalhandler": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.0.0.tgz",
-			"integrity": "sha512-MX6Zo2adDViYh+GcxxB1dpO43eypOGUOL12rLCOTMQv/DfIbpSJUy4oQIIZhVZkH9e+bZWKMon0XHFEju16tkQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
 			"dependencies": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "2.4.1",
-				"parseurl": "~1.3.3",
-				"statuses": "2.0.1",
-				"unpipe": "~1.0.0"
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
 			},
 			"engines": {
-				"node": ">= 0.8"
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
-		},
-		"node_modules/finalhandler/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/finalhandler/node_modules/encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/finalhandler/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
 		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
@@ -6591,10 +6604,11 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-			"integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
-			"dev": true
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/fn.name": {
 			"version": "1.1.0",
@@ -6665,6 +6679,7 @@
 			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
 			"integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 14.17"
 			}
@@ -6722,6 +6737,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
 			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -6730,6 +6746,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
 			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -6891,23 +6908,18 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-12.0.0.tgz",
-			"integrity": "sha512-5Qcll1z7IKgHr5g485ePDdHcNQY0k2dtv/bjYy0iuyGxQw2qSOiiXUXJ+AYQpg3HNoUMHqAruX478Jeev7UULw==",
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
 			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"foreground-child": "^3.3.1",
-				"jackspeak": "^4.1.1",
-				"minimatch": "^10.1.1",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^2.0.0"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -6929,18 +6941,43 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"dev": true
-		},
-		"node_modules/glob/node_modules/minimatch": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-			"integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
 			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/glob/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/glob/node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@isaacs/brace-expansion": "^5.0.0"
+				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -7019,6 +7056,7 @@
 			"resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
 			"integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/is": "^5.2.0",
 				"@szmarczak/http-timer": "^5.0.1",
@@ -7142,24 +7180,30 @@
 			"dev": true
 		},
 		"node_modules/http-cache-semantics": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-			"dev": true
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/http-errors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
 			"dependencies": {
-				"depd": "2.0.0",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"toidentifier": "1.0.1"
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/http2-wrapper": {
@@ -7167,6 +7211,7 @@
 			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
 			"integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"quick-lru": "^5.1.1",
 				"resolve-alpn": "^1.2.0"
@@ -7197,14 +7242,19 @@
 			}
 		},
 		"node_modules/iconv-lite": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-			"integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
 			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/ieee754": {
@@ -7312,6 +7362,7 @@
 			"resolved": "https://registry.npmjs.org/inspect-with-kind/-/inspect-with-kind-1.0.5.tgz",
 			"integrity": "sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"kind-of": "^6.0.2"
 			}
@@ -7343,6 +7394,7 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
 			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
 			}
@@ -7428,6 +7480,7 @@
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7435,7 +7488,8 @@
 		"node_modules/is-promise": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"license": "MIT"
 		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
@@ -7459,11 +7513,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -7551,21 +7600,6 @@
 			"integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/jackspeak": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-			"dev": true,
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/jake": {
@@ -8125,10 +8159,11 @@
 			}
 		},
 		"node_modules/jest-util/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -8235,9 +8270,10 @@
 			}
 		},
 		"node_modules/js-beautify/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -8281,11 +8317,12 @@
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
 		},
 		"node_modules/js-beautify/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -8394,7 +8431,8 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
 			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/jsonfile": {
 			"version": "6.1.0",
@@ -8441,12 +8479,12 @@
 			}
 		},
 		"node_modules/jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+			"integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
 			"license": "MIT",
 			"dependencies": {
-				"jwa": "^1.4.1",
+				"jwa": "^1.4.2",
 				"safe-buffer": "^5.0.1"
 			}
 		},
@@ -8464,6 +8502,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8517,9 +8556,9 @@
 			"dev": true
 		},
 		"node_modules/load-esm": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.2.tgz",
-			"integrity": "sha512-nVAvWk/jeyrWyXEAs84mpQCYccxRqgKY4OznLuJhJCa0XsPSfdOIr2zvBZEj3IHEHbX97jjscKRRV539bW0Gpw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
+			"integrity": "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==",
 			"funding": [
 				{
 					"type": "github",
@@ -8530,17 +8569,23 @@
 					"url": "https://buymeacoffee.com/borewit"
 				}
 			],
+			"license": "MIT",
 			"engines": {
 				"node": ">=13.2.0"
 			}
 		},
 		"node_modules/loader-runner": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+			"integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.11.5"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/locate-path": {
@@ -8559,9 +8604,10 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+			"license": "MIT"
 		},
 		"node_modules/lodash.defaults": {
 			"version": "4.2.0",
@@ -8676,6 +8722,7 @@
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
 			"integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
@@ -8697,6 +8744,7 @@
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
 			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
 			}
@@ -8743,6 +8791,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
 			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -8763,6 +8812,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
 			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -8789,6 +8839,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
 			"integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -8807,10 +8858,11 @@
 			}
 		},
 		"node_modules/micromatch/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -8831,22 +8883,28 @@
 			}
 		},
 		"node_modules/mime-db": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
-			"integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mime-types": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.0.tgz",
-			"integrity": "sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
 			"dependencies": {
-				"mime-db": "^1.53.0"
+				"mime-db": "^1.54.0"
 			},
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -8863,6 +8921,7 @@
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
 			"integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
@@ -8871,9 +8930,10 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -8885,27 +8945,18 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
 			}
 		},
 		"node_modules/moment": {
@@ -8933,26 +8984,29 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"node_modules/multer": {
-			"version": "1.4.5-lts.1",
-			"resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
-			"integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+			"integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+			"license": "MIT",
 			"dependencies": {
 				"append-field": "^1.0.0",
-				"busboy": "^1.0.0",
-				"concat-stream": "^1.5.2",
-				"mkdirp": "^0.5.4",
-				"object-assign": "^4.1.1",
-				"type-is": "^1.6.4",
-				"xtend": "^4.0.0"
+				"busboy": "^1.6.0",
+				"concat-stream": "^2.0.0",
+				"type-is": "^1.6.18"
 			},
 			"engines": {
-				"node": ">= 6.0.0"
+				"node": ">= 10.16.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/multer/node_modules/media-typer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -8961,6 +9015,7 @@
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -8969,6 +9024,7 @@
 			"version": "2.1.35",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
 			"dependencies": {
 				"mime-db": "1.52.0"
 			},
@@ -8980,6 +9036,7 @@
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
 			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"license": "MIT",
 			"dependencies": {
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.24"
@@ -9007,6 +9064,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
 			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -9106,10 +9164,11 @@
 			"dev": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-			"dev": true
+			"version": "2.0.37",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+			"integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/nopt": {
 			"version": "7.2.1",
@@ -9135,10 +9194,11 @@
 			}
 		},
 		"node_modules/normalize-url": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
-			"integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+			"integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.16"
 			},
@@ -9162,6 +9222,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9181,6 +9242,7 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
 			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
 			"dependencies": {
 				"ee-first": "1.1.1"
 			},
@@ -9294,6 +9356,7 @@
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
 			"integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12.20"
 			}
@@ -9411,36 +9474,40 @@
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
 		},
 		"node_modules/path-scurry": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-			"integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
 			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"lru-cache": "^11.0.0",
 				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/path-scurry/node_modules/lru-cache": {
-			"version": "11.2.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-			"integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
 			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
 			}
 		},
 		"node_modules/path-to-regexp": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-			"integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-			"engines": {
-				"node": ">=16"
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/path-type": {
@@ -9452,24 +9519,12 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/peek-readable": {
-			"version": "5.4.2",
-			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
-			"integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pg": {
 			"version": "8.13.1",
@@ -9569,10 +9624,11 @@
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -9768,11 +9824,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-		},
 		"node_modules/prom-client": {
 			"version": "15.1.3",
 			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
@@ -9808,6 +9859,7 @@
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
 			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
 			"dependencies": {
 				"forwarded": "0.2.0",
 				"ipaddr.js": "1.9.1"
@@ -9842,11 +9894,12 @@
 			]
 		},
 		"node_modules/qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+			"version": "6.15.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.0.6"
+				"side-channel": "^1.1.0"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -9880,6 +9933,7 @@
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
 			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -9896,46 +9950,28 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
 			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/raw-body": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-			"integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
 			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.6.3",
-				"unpipe": "1.0.0"
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
 			},
 			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/raw-body/node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/react-is": {
@@ -9945,23 +9981,18 @@
 			"dev": true
 		},
 		"node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
 			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
-		},
-		"node_modules/readable-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/readdirp": {
 			"version": "4.1.1",
@@ -10059,7 +10090,8 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
 			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/resolve-cwd": {
 			"version": "3.0.0",
@@ -10105,6 +10137,7 @@
 			"resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
 			"integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"lowercase-keys": "^3.0.0"
 			},
@@ -10164,9 +10197,10 @@
 			}
 		},
 		"node_modules/rimraf/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -10210,11 +10244,12 @@
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
 		},
 		"node_modules/rimraf/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -10239,20 +10274,19 @@
 			}
 		},
 		"node_modules/router": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/router/-/router-2.0.0.tgz",
-			"integrity": "sha512-dIM5zVoG8xhC6rnSN8uoAgFARwTE7BQs8YwHEvK0VCmfxQXMaOuA1uiR1IPwsW7JyK5iTt7Od/TC9StasS2NPQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"license": "MIT",
 			"dependencies": {
-				"array-flatten": "3.0.0",
-				"is-promise": "4.0.0",
-				"methods": "~1.1.2",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "^8.0.0",
-				"setprototypeof": "1.2.0",
-				"utils-merge": "1.0.1"
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
 			},
 			"engines": {
-				"node": ">= 0.10"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -10342,6 +10376,7 @@
 			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-2.0.0.tgz",
 			"integrity": "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"commander": "^6.0.0"
 			},
@@ -10355,6 +10390,7 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
 			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
 			}
@@ -10398,64 +10434,42 @@
 			}
 		},
 		"node_modules/send": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-1.1.0.tgz",
-			"integrity": "sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.3.5",
-				"destroy": "^1.2.0",
+				"debug": "^4.4.3",
 				"encodeurl": "^2.0.0",
 				"escape-html": "^1.0.3",
 				"etag": "^1.8.1",
-				"fresh": "^0.5.2",
-				"http-errors": "^2.0.0",
-				"mime-types": "^2.1.35",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
 				"ms": "^2.1.3",
 				"on-finished": "^2.4.1",
 				"range-parser": "^1.2.1",
-				"statuses": "^2.0.1"
+				"statuses": "^2.0.2"
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/send/node_modules/fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/send/node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/send/node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dependencies": {
-				"mime-db": "1.52.0"
 			},
-			"engines": {
-				"node": ">= 0.6"
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/sequelize": {
-			"version": "6.37.7",
-			"resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.37.7.tgz",
-			"integrity": "sha512-mCnh83zuz7kQxxJirtFD7q6Huy6liPanI67BSlbzSYgVNl5eXVdE2CN1FuAeZwG1SNpGsNRCV+bJAVVnykZAFA==",
+			"version": "6.37.8",
+			"resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.37.8.tgz",
+			"integrity": "sha512-HJ0IQFqcTsTiqbEgiuioYFMSD00TP6Cz7zoTti+zVVBwVe9fEhev9cH6WnM3XU31+ABS356durAb99ZuOthnKw==",
 			"funding": [
 				{
 					"type": "opencollective",
 					"url": "https://opencollective.com/sequelize"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"@types/debug": "^4.1.8",
 				"@types/validator": "^13.7.17",
@@ -10666,33 +10680,30 @@
 				"uuid": "dist/bin/uuid"
 			}
 		},
-		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-			"dev": true,
-			"dependencies": {
-				"randombytes": "^2.1.0"
-			}
-		},
 		"node_modules/serve-static": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.1.0.tgz",
-			"integrity": "sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
 			"dependencies": {
 				"encodeurl": "^2.0.0",
 				"escape-html": "^1.0.3",
 				"parseurl": "^1.3.3",
-				"send": "^1.0.0"
+				"send": "^1.2.0"
 			},
 			"engines": {
 				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/setprototypeof": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC"
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -10812,6 +10823,7 @@
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
 			"integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-plain-obj": "^1.0.0"
 			},
@@ -10824,6 +10836,7 @@
 			"resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
 			"integrity": "sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"sort-keys": "^1.0.0"
 			},
@@ -10910,9 +10923,10 @@
 			"license": "MIT"
 		},
 		"node_modules/statuses": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -10926,16 +10940,15 @@
 			}
 		},
 		"node_modules/streamx": {
-			"version": "2.22.0",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
-			"integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+			"integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
+				"events-universal": "^1.0.0",
 				"fast-fifo": "^1.3.2",
 				"text-decoder": "^1.1.0"
-			},
-			"optionalDependencies": {
-				"bare-events": "^2.2.0"
 			}
 		},
 		"node_modules/string_decoder": {
@@ -11098,6 +11111,7 @@
 			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-3.0.0.tgz",
 			"integrity": "sha512-I0sdgcFTfKQlUPZyAqPJmSG3HLO9rWDFnxonnIbskYNM3DwFOeTNB5KzVq3dA1GdRAc/25b5Y7UO2TQfKWw4aQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"inspect-with-kind": "^1.0.5",
 				"is-plain-obj": "^1.1.0"
@@ -11125,16 +11139,15 @@
 			}
 		},
 		"node_modules/strtok3": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
-			"integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
-			"dev": true,
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+			"license": "MIT",
 			"dependencies": {
-				"@tokenizer/token": "^0.3.0",
-				"peek-readable": "^5.3.1"
+				"@tokenizer/token": "^0.3.0"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			},
 			"funding": {
 				"type": "github",
@@ -11198,9 +11211,10 @@
 			}
 		},
 		"node_modules/swagger-ui-dist": {
-			"version": "5.30.2",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.30.2.tgz",
-			"integrity": "sha512-HWCg1DTNE/Nmapt+0m2EPXFwNKNeKK4PwMjkwveN/zn1cV2Kxi9SURd+m0SpdcSgWEK/O64sf8bzXdtUhigtHA==",
+			"version": "5.32.2",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.2.tgz",
+			"integrity": "sha512-t6Ns52nS8LU2hqi0+rezMjFO1ZrCsCrnommXrU7Nfrg2va2dWahdvM6TuSwzdHpG29v6BHJyU1c/UWFhgVZzVQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@scarf/scarf": "=1.4.0"
 			}
@@ -11210,6 +11224,7 @@
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
 			"integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10"
 			}
@@ -11231,21 +11246,28 @@
 			}
 		},
 		"node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+			"integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/tar-stream": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+			"integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"b4a": "^1.6.4",
+				"bare-fs": "^4.5.5",
 				"fast-fifo": "^1.2.0",
 				"streamx": "^2.15.0"
 			}
@@ -11259,14 +11281,25 @@
 				"bintrees": "1.0.2"
 			}
 		},
-		"node_modules/terser": {
-			"version": "5.38.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.38.1.tgz",
-			"integrity": "sha512-GWANVlPM/ZfYzuPHjq0nxT+EbOEDDN3Jwhwdg1D8TU8oSkktp8w64Uq4auuGLxFSoNTRDncTq2hQHX1Ld9KHkA==",
+		"node_modules/teex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"streamx": "^2.12.5"
+			}
+		},
+		"node_modules/terser": {
+			"version": "5.46.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
+			"integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
-				"acorn": "^8.8.2",
+				"acorn": "^8.15.0",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
 			},
@@ -11278,15 +11311,15 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.11",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz",
-			"integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+			"integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^4.3.0",
-				"serialize-javascript": "^6.0.2",
 				"terser": "^5.31.1"
 			},
 			"engines": {
@@ -11312,10 +11345,11 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -11332,6 +11366,7 @@
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
 			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.0.0"
 			},
@@ -11349,6 +11384,7 @@
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
 			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3"
 			},
@@ -11361,6 +11397,7 @@
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
 			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -11374,13 +11411,15 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-			"integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"ajv": "^8.9.0",
@@ -11400,6 +11439,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -11414,7 +11454,8 @@
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
@@ -11452,10 +11493,11 @@
 			}
 		},
 		"node_modules/text-decoder": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+			"integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"b4a": "^1.6.4"
 			}
@@ -11470,7 +11512,8 @@
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
@@ -11494,15 +11537,18 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
 			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.6"
 			}
 		},
 		"node_modules/token-types": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
-			"integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"license": "MIT",
 			"dependencies": {
+				"@borewit/text-codec": "^0.2.1",
 				"@tokenizer/token": "^0.3.0",
 				"ieee754": "^1.2.1"
 			},
@@ -11728,9 +11774,10 @@
 			}
 		},
 		"node_modules/type-is": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.0.tgz",
-			"integrity": "sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+			"license": "MIT",
 			"dependencies": {
 				"content-type": "^1.0.5",
 				"media-typer": "^1.1.0",
@@ -11743,7 +11790,8 @@
 		"node_modules/typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+			"license": "MIT"
 		},
 		"node_modules/typescript": {
 			"version": "5.7.3",
@@ -11830,15 +11878,17 @@
 			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
 			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"buffer": "^5.2.1",
 				"through": "^2.3.8"
 			}
 		},
 		"node_modules/underscore": {
-			"version": "1.13.7",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-			"integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
+			"version": "1.13.8",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+			"integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+			"license": "MIT"
 		},
 		"node_modules/undici-types": {
 			"version": "6.20.0",
@@ -11857,14 +11907,15 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
-			"integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"dev": true,
 			"funding": [
 				{
@@ -11880,6 +11931,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"escalade": "^3.2.0",
 				"picocolors": "^1.1.1"
@@ -11904,14 +11956,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-		},
-		"node_modules/utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-			"engines": {
-				"node": ">= 0.4.0"
-			}
 		},
 		"node_modules/uuid": {
 			"version": "11.1.0",
@@ -11958,6 +12002,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -11972,10 +12017,11 @@
 			}
 		},
 		"node_modules/watchpack": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+			"integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -12014,10 +12060,11 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.100.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
-			"integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
+			"version": "5.106.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.0.tgz",
+			"integrity": "sha512-Pkx5joZ9RrdgO5LBkyX1L2ZAJeK/Taz3vqZ9CbcP0wS5LEMx5QkKsEwLl29QJfihZ+DKRBFldzy1O30pJ1MDpA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -12025,25 +12072,25 @@
 				"@webassemblyjs/ast": "^1.14.1",
 				"@webassemblyjs/wasm-edit": "^1.14.1",
 				"@webassemblyjs/wasm-parser": "^1.14.1",
-				"acorn": "^8.15.0",
+				"acorn": "^8.16.0",
 				"acorn-import-phases": "^1.0.3",
-				"browserslist": "^4.24.0",
+				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.2",
-				"es-module-lexer": "^1.2.1",
+				"enhanced-resolve": "^5.20.0",
+				"es-module-lexer": "^2.0.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.11",
 				"json-parse-even-better-errors": "^2.3.1",
-				"loader-runner": "^4.2.0",
+				"loader-runner": "^4.3.1",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^4.3.2",
-				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.3.11",
-				"watchpack": "^2.4.1",
-				"webpack-sources": "^3.3.3"
+				"schema-utils": "^4.3.3",
+				"tapable": "^2.3.0",
+				"terser-webpack-plugin": "^5.3.17",
+				"watchpack": "^2.5.1",
+				"webpack-sources": "^3.3.4"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -12071,19 +12118,21 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-			"integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+			"integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/webpack/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -12242,20 +12291,6 @@
 				"node": ">= 12.0.0"
 			}
 		},
-		"node_modules/winston-transport/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/winston/node_modules/@colors/colors": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -12263,20 +12298,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.1.90"
-			}
-		},
-		"node_modules/winston/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/wkx": {
@@ -12441,10 +12462,11 @@
 			}
 		},
 		"node_modules/yauzl": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
-			"integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+			"integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"buffer-crc32": "~0.2.3",
 				"pend": "~1.2.0"

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -54,16 +54,16 @@ export class AuthController {
 			sameSite: isProduction ? 'none' : 'lax',
 			maxAge: 15 * 60 * 1000,
 		});
-		return data;
+		return { message: 'Authenticated successfully.' };
 	}
 
 	@UseGuards(AuthGuard)
 	@Delete('logout')
-	logoutUser(
+	async logoutUser(
 		@Req() req: Request,
 		@Res({ passthrough: true }) res: Response,
 	) {
-		const token = extractTokenFromCookie(req, 'access_token');
+		const token = extractTokenFromCookie(req, 'refresh_token');
 
 		if (!token) {
 			throw new UnauthorizedException('Token not found.');
@@ -71,7 +71,7 @@ export class AuthController {
 
 		const isProduction = process.env.NODE_ENV === 'production';
 
-		void this.authService.logout(token);
+		await this.authService.logout(token);
 
 		res.clearCookie('refresh_token', {
 			httpOnly: true,
@@ -117,7 +117,7 @@ export class AuthController {
 			maxAge: 15 * 60 * 1000,
 		});
 
-		return data;
+		return { message: 'Tokens refreshed successfully.' };
 	}
 
 	@HttpCode(HttpStatus.OK)
@@ -144,6 +144,6 @@ export class AuthController {
 			sameSite: isProduction ? 'none' : 'lax',
 			maxAge: 15 * 60 * 1000,
 		});
-		return data;
+		return { message: 'Authenticated successfully.' };
 	}
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { UsersModule } from 'src/user/users.module';
 import { JwtModule } from '@nestjs/jwt';
 import { TokenService } from './token.service';
 import { AuthGuard } from './guards/auth.guard';
+import { AdminGuard } from './guards/admin.guard';
 import { jwtConstants } from 'src/constants';
 import { RedisModule } from 'src/redis/redis.module';
 import { GoogleAuthService } from './googleAuth.service';
@@ -24,7 +25,7 @@ import { RabbitmqModule } from 'src/rabbitmq/rabbitmq.module';
 		RabbitmqModule,
 	],
 	controllers: [AuthController],
-	providers: [AuthGuard, AuthService, TokenService, GoogleAuthService],
-	exports: [AuthService],
+	providers: [AuthGuard, AdminGuard, AuthService, TokenService, GoogleAuthService],
+	exports: [AuthService, AuthGuard, AdminGuard],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -26,7 +26,16 @@ export class AuthService {
 			const user = await this.usersService.createUser(data);
 			await this.emailService.sendWelcomeEmail(user);
 
-			return user;
+			return {
+				id: user.id,
+				name: user.name,
+				slug: user.slug,
+				email: user.email,
+				profileImgUrl: user.profileImgUrl,
+				bio: user.bio,
+				followersNumber: user.followersNumber,
+				createdAt: user.createdAt,
+			};
 		} catch (err: unknown) {
 			if (
 				err instanceof Error &&

--- a/backend/src/auth/googleAuth.service.ts
+++ b/backend/src/auth/googleAuth.service.ts
@@ -13,13 +13,8 @@ export class GoogleAuthService {
 		private readonly tokenService: TokenService,
 		private readonly userService: UsersService,
 	) {
-		const certsUrl = 'http://nginx/google-certs/';
-
 		this.client = new OAuth2Client({
 			clientId: process.env.GOOGLE_CLIENT_ID,
-			endpoints: {
-				oauth2FederatedSignonPemCertsUrl: certsUrl,
-			},
 		});
 	}
 
@@ -40,7 +35,12 @@ export class GoogleAuthService {
 			throw new UnauthorizedException('Invalid Google token.');
 		}
 
-		if (!payload?.sub || !payload.email || !payload.name) {
+		if (
+			!payload?.sub ||
+			!payload.email ||
+			!payload.name ||
+			payload.email_verified !== true
+		) {
 			throw new UnauthorizedException('Invalid Google token.');
 		}
 

--- a/backend/src/auth/guards/auth.guard.ts
+++ b/backend/src/auth/guards/auth.guard.ts
@@ -27,8 +27,7 @@ export class AuthGuard implements CanActivate {
 			});
 
 			request.user = payload;
-		} catch (e) {
-			console.log(e);
+		} catch {
 			throw new UnauthorizedException();
 		}
 		return true;

--- a/backend/src/database/database.provider.ts
+++ b/backend/src/database/database.provider.ts
@@ -37,18 +37,18 @@ export const databaseProviders = [
 				database: process.env.POSTGRES_DB,
 				benchmark: true,
 				logging: (sql, timing) => {
-					// Log normal
+					const queryType = sql.split(' ')[0].toUpperCase();
+					const modelMatch = sql.match(/FROM\s+"?(\w+)"?/i);
+					const model = modelMatch ? modelMatch[1] : 'unknown';
+
 					logger.log('Sequelize query', {
 						type: 'db',
-						query: sql,
+						queryType,
+						model,
 						duration: timing,
 					});
 
 					// Increment Prometheus metrics
-					const queryType = sql.split(' ')[0].toUpperCase(); // SELECT, INSERT, etc.
-					const modelMatch = sql.match(/FROM\s+"?(\w+)"?/i);
-					const model = modelMatch ? modelMatch[1] : 'unknown';
-
 					dbQueryTotal.inc({ model, type: queryType });
 					if (timing) {
 						dbQueryDuration.observe(

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -18,7 +18,13 @@ async function bootstrap() {
 		origin: ['https://sunlog.dev', 'http://localhost'],
 		credentials: true,
 	});
-	app.useGlobalPipes(new ValidationPipe());
+	app.useGlobalPipes(
+		new ValidationPipe({
+			whitelist: true,
+			forbidNonWhitelisted: true,
+			transform: true,
+		}),
+	);
 	app.useGlobalFilters(new GlobalFilter());
 	app.useGlobalInterceptors(new HttpMetricsInterceptor());
 

--- a/backend/src/project/dtos/updateProject.dto.ts
+++ b/backend/src/project/dtos/updateProject.dto.ts
@@ -1,0 +1,26 @@
+import {
+	IsString,
+	MinLength,
+	MaxLength,
+	IsOptional,
+	Matches,
+} from 'class-validator';
+
+export class UpdateProjectDto {
+	@IsOptional()
+	@IsString()
+	@MinLength(3)
+	@MaxLength(60)
+	@Matches(/^[^/\\]+$/, {
+		message: "Name cannot contain '/' or '\\'",
+	})
+	name?: string;
+
+	@IsOptional()
+	@IsString()
+	description?: string;
+
+	@IsOptional()
+	@IsString()
+	content?: string;
+}

--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -13,6 +13,7 @@ import { ProjectService } from './project.service';
 import { AuthRequest } from 'src/interfaces/authRequest.interface';
 import { AuthGuard } from 'src/auth/guards/auth.guard';
 import { CreateProjectDto } from './dtos/createProject.dto';
+import { UpdateProjectDto } from './dtos/updateProject.dto';
 
 @Controller('projects')
 export class ProjectController {
@@ -59,7 +60,7 @@ export class ProjectController {
 	async update(
 		@Req() req: AuthRequest,
 		@Param('id') id: string,
-		@Body() data: Partial<CreateProjectDto>,
+		@Body() data: UpdateProjectDto,
 	) {
 		const userId = req.user.userId;
 		return await this.projectService.updateProject(id, userId, data);

--- a/backend/src/project/project.service.ts
+++ b/backend/src/project/project.service.ts
@@ -11,6 +11,7 @@ import {
 	projectRepositoryToken,
 } from 'src/constants';
 import { CreateProjectDto } from './dtos/createProject.dto';
+import { UpdateProjectDto } from './dtos/updateProject.dto';
 import { DevlogEvent } from 'src/devlog-event/devlog-event.entity';
 import { User } from 'src/user/user.entity';
 import { col } from 'sequelize';
@@ -38,7 +39,9 @@ export class ProjectService {
 		}
 
 		return await this.projectRepository.create({
-			...data,
+			name: data.name,
+			description: data.description,
+			readme: data.content,
 			slug: data.name.toLowerCase().replace(' ', '_'),
 			userId,
 		});
@@ -95,7 +98,7 @@ export class ProjectService {
 		});
 	}
 
-	async updateProject(id: string, userId: string, data: any) {
+	async updateProject(id: string, userId: string, data: UpdateProjectDto) {
 		const project = await this.projectRepository.findOne({
 			where: {
 				id,
@@ -113,7 +116,22 @@ export class ProjectService {
 			);
 		}
 
-		await this.projectRepository.update(data as Partial<Project>, {
+		const updateData: Partial<Project> = {};
+
+		if (typeof data.name === 'string') {
+			updateData.name = data.name;
+			updateData.slug = data.name.toLowerCase().replace(' ', '_');
+		}
+
+		if (typeof data.description === 'string') {
+			updateData.description = data.description;
+		}
+
+		if (typeof data.content === 'string') {
+			updateData.readme = data.content;
+		}
+
+		await this.projectRepository.update(updateData, {
 			where: { id },
 		});
 		return this.projectRepository.findByPk(id);

--- a/backend/src/user/users.service.ts
+++ b/backend/src/user/users.service.ts
@@ -191,12 +191,23 @@ export class UsersService {
 	}
 
 	async updateUser(id: string, data: updateUserDto) {
-		return this.usersRepository.update(data, {
+		const updateData = {
+			name: data.name,
+			bio: data.bio,
+			profileImgUrl: data.profileImgUrl,
+		};
+
+		const [affected] = await this.usersRepository.update(updateData, {
 			where: {
 				id,
 			},
-			returning: true,
 		});
+
+		if (!affected) {
+			throw new NotFoundException('User does not exist.');
+		}
+
+		return this.findLoggedUser(id);
 	}
 
 	async getTrendingUsers() {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1317,9 +1317,10 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.3.tgz",
-			"integrity": "sha512-IqgtY5Vwsm14mm/nmQaRMmywCU+yyMIYfk3/MHZ2ZTJvwVbBn3usZnjMi1GacrMVzVcAxJShTCpZlPs26EdEjQ=="
+			"version": "16.2.3",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+			"integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
+			"license": "MIT"
 		},
 		"node_modules/@next/eslint-plugin-next": {
 			"version": "15.3.4",
@@ -1331,12 +1332,13 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.3.tgz",
-			"integrity": "sha512-MOnbd92+OByu0p6QBAzq1ahVWzF6nyfiH07dQDez4/Nku7G249NjxDVyEfVhz8WkLiOEU+KFVnqtgcsfP2nLXg==",
+			"version": "16.2.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+			"integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1346,12 +1348,13 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.3.tgz",
-			"integrity": "sha512-i70C4O1VmbTivYdRlk+5lj9xRc2BlK3oUikt3yJeHT1unL4LsNtN7UiOhVanFdc7vDAgZn1tV/9mQwMkWOJvHg==",
+			"version": "16.2.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+			"integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1361,12 +1364,16 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.3.tgz",
-			"integrity": "sha512-O88gCZ95sScwD00mn/AtalyCoykhhlokxH/wi1huFK+rmiP5LAYVs/i2ruk7xST6SuXN4NI5y4Xf5vepb2jf6A==",
+			"version": "16.2.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+			"integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1376,12 +1383,16 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.3.tgz",
-			"integrity": "sha512-CEErFt78S/zYXzFIiv18iQCbRbLgBluS8z1TNDQoyPi8/Jr5qhR3e8XHAIxVxPBjDbEMITprqELVc5KTfFj0gg==",
+			"version": "16.2.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+			"integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1391,12 +1402,16 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.3.tgz",
-			"integrity": "sha512-Tc3i+nwt6mQ+Dwzcri/WNDj56iWdycGVh5YwwklleClzPzz7UpfaMw1ci7bLl6GRYMXhWDBfe707EXNjKtiswQ==",
+			"version": "16.2.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+			"integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1406,12 +1421,16 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.3.tgz",
-			"integrity": "sha512-zTh03Z/5PBBPdTurgEtr6nY0vI9KR9Ifp/jZCcHlODzwVOEKcKRBtQIGrkc7izFgOMuXDEJBmirwpGqdM/ZixA==",
+			"version": "16.2.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+			"integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1421,12 +1440,13 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.3.tgz",
-			"integrity": "sha512-Jc1EHxtZovcJcg5zU43X3tuqzl/sS+CmLgjRP28ZT4vk869Ncm2NoF8qSTaL99gh6uOzgM99Shct06pSO6kA6g==",
+			"version": "16.2.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+			"integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1436,12 +1456,13 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.3.tgz",
-			"integrity": "sha512-N7EJ6zbxgIYpI/sWNzpVKRMbfEGgsWuOIvzkML7wxAAZhPk1Msxuo/JDu1PKjWGrAoOLaZcIX5s+/pF5LIbBBg==",
+			"version": "16.2.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+			"integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -2108,10 +2129,11 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -2145,12 +2167,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -2476,10 +2499,11 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -2718,13 +2742,14 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-			"integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.4",
-				"proxy-from-env": "^1.1.0"
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
+				"proxy-from-env": "^2.1.0"
 			}
 		},
 		"node_modules/axobject-query": {
@@ -2765,11 +2790,24 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.19",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+			"integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -4004,21 +4042,23 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-			"dev": true
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
 			"funding": [
 				{
 					"type": "individual",
 					"url": "https://github.com/sponsors/RubenVerborgh"
 				}
 			],
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0"
 			},
@@ -5644,9 +5684,10 @@
 			}
 		},
 		"node_modules/mdast-util-to-hast": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-			"integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+			"integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0",
 				"@types/mdast": "^4.0.0",
@@ -6272,10 +6313,11 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -6302,30 +6344,16 @@
 			}
 		},
 		"node_modules/minizlib": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-			"integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"minipass": "^7.1.2"
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/mkdirp": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-			"dev": true,
-			"bin": {
-				"mkdirp": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/ms": {
@@ -6372,12 +6400,14 @@
 			"dev": true
 		},
 		"node_modules/next": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/next/-/next-16.0.3.tgz",
-			"integrity": "sha512-Ka0/iNBblPFcIubTA1Jjh6gvwqfjrGq1Y2MTI5lbjeLIAfmC+p5bQmojpRZqgHHVu5cG4+qdIiwXiBSm/8lZ3w==",
+			"version": "16.2.3",
+			"resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+			"integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
+			"license": "MIT",
 			"dependencies": {
-				"@next/env": "16.0.3",
+				"@next/env": "16.2.3",
 				"@swc/helpers": "0.5.15",
+				"baseline-browser-mapping": "^2.9.19",
 				"caniuse-lite": "^1.0.30001579",
 				"postcss": "8.4.31",
 				"styled-jsx": "5.1.6"
@@ -6389,15 +6419,15 @@
 				"node": ">=20.9.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "16.0.3",
-				"@next/swc-darwin-x64": "16.0.3",
-				"@next/swc-linux-arm64-gnu": "16.0.3",
-				"@next/swc-linux-arm64-musl": "16.0.3",
-				"@next/swc-linux-x64-gnu": "16.0.3",
-				"@next/swc-linux-x64-musl": "16.0.3",
-				"@next/swc-win32-arm64-msvc": "16.0.3",
-				"@next/swc-win32-x64-msvc": "16.0.3",
-				"sharp": "^0.34.4"
+				"@next/swc-darwin-arm64": "16.2.3",
+				"@next/swc-darwin-x64": "16.2.3",
+				"@next/swc-linux-arm64-gnu": "16.2.3",
+				"@next/swc-linux-arm64-musl": "16.2.3",
+				"@next/swc-linux-x64-gnu": "16.2.3",
+				"@next/swc-linux-x64-musl": "16.2.3",
+				"@next/swc-win32-arm64-msvc": "16.2.3",
+				"@next/swc-win32-x64-msvc": "16.2.3",
+				"sharp": "^0.34.5"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",
@@ -6726,10 +6756,11 @@
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -6831,9 +6862,13 @@
 			}
 		},
 		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
@@ -7650,16 +7685,16 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-			"integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+			"integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
 			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
 				"chownr": "^3.0.0",
 				"minipass": "^7.1.2",
-				"minizlib": "^3.0.1",
-				"mkdirp": "^3.0.1",
+				"minizlib": "^3.1.0",
 				"yallist": "^5.0.0"
 			},
 			"engines": {
@@ -7697,10 +7732,11 @@
 			}
 		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -8187,9 +8223,10 @@
 			}
 		},
 		"node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+			"license": "ISC",
 			"engines": {
 				"node": ">= 6"
 			}

--- a/infra/nginx.dev.conf
+++ b/infra/nginx.dev.conf
@@ -9,14 +9,6 @@ http {
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     client_max_body_size 1M;
     
-    # Cache path must be defined in http block, NOT inside location
-    proxy_cache_path /var/cache/nginx/google_certs 
-        levels=1:2 
-        keys_zone=google_certs:10m 
-        max_size=10m 
-        inactive=60m 
-        use_temp_path=off;
-    
     server {
         listen 80;
         
@@ -30,6 +22,10 @@ http {
             proxy_set_header X-Forwarded-Proto https;
         }
         
+        location = /api/metrics {
+            deny all;
+        }
+
         location /api/ {
             proxy_pass http://api:3000;
             proxy_hide_header X-Powered-By;
@@ -47,50 +43,6 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto http;
             proxy_redirect off;
-        }
-        
-        location /google-certs/ {
-            # Proxy to Google's certificate endpoint
-            proxy_pass https://www.googleapis.com/oauth2/v1/certs;
-            
-            # SSL configuration for HTTPS upstream
-            proxy_ssl_server_name on;
-            proxy_ssl_protocols TLSv1.2 TLSv1.3;
-            proxy_set_header Host www.googleapis.com;
-            
-            # Don't pass request body (GET request)
-            proxy_pass_request_body off;
-            proxy_set_header Content-Length "";
-            
-            # Set proper headers
-            proxy_set_header Accept "application/json";
-            proxy_set_header User-Agent "nginx-proxy";
-            
-            # Don't modify the response
-            proxy_http_version 1.1;
-            proxy_set_header Connection "";
-            
-            # Cache configuration
-            proxy_cache google_certs;
-            proxy_cache_valid 200 1h;
-            proxy_cache_key "$request_uri";
-            proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
-            proxy_cache_lock on;
-            proxy_cache_lock_timeout 5s;
-            
-            # Add cache status header for debugging
-            add_header X-Cache-Status $upstream_cache_status always;
-            
-            # Timeouts
-            proxy_connect_timeout 10s;
-            proxy_send_timeout 10s;
-            proxy_read_timeout 10s;
-            
-            # Buffering (important for proper response handling)
-            proxy_buffering on;
-            proxy_buffer_size 4k;
-            proxy_buffers 8 4k;
-            proxy_busy_buffers_size 8k;
         }
         
         location ~ /\.(git|env|htaccess|htpasswd) {

--- a/infra/nginx.prod.conf
+++ b/infra/nginx.prod.conf
@@ -14,26 +14,6 @@ http {
         listen 80;
         server_name sunlog.dev www.sunlog.dev;
 
-        location /google-certs/ {
-            proxy_pass https://www.googleapis.com/oauth2/v1/certs;
-            proxy_ssl_server_name on;
-            proxy_ssl_protocols TLSv1.2 TLSv1.3;
-            proxy_set_header Host www.googleapis.com;
-            proxy_pass_request_body off;
-            proxy_set_header Content-Length "";
-            proxy_set_header Accept "application/json";
-            proxy_set_header User-Agent "nginx-proxy";
-            proxy_http_version 1.1;
-            proxy_set_header Connection "";
-            proxy_connect_timeout 10s;
-            proxy_send_timeout 10s;
-            proxy_read_timeout 10s;
-            proxy_buffering on;
-            proxy_buffer_size 4k;
-            proxy_buffers 8 4k;
-            proxy_busy_buffers_size 8k;
-        }
-
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Content-Type-Options nosniff always;
         add_header X-Frame-Options DENY always;
@@ -53,6 +33,10 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        }
+
+        location = /api/metrics {
+            deny all;
         }
 
         # API


### PR DESCRIPTION
## Context
This branch tightens backend API behavior around authentication, request validation, and project update handling. It also removes obsolete Google cert proxying, blocks direct metrics exposure at the proxy, and refreshes lockfiles for the backend and frontend.

---

## Changes Made

### Added
- Added `UpdateProjectDto` to validate partial project updates and reject invalid project names containing `/` or `\\`.

### Modified
- Standardized auth endpoint responses and updated logout to use the `refresh_token` cookie while awaiting token revocation.
- Hardened Google auth by removing the custom cert endpoint override and requiring verified Google email claims.
- Enabled stricter global Nest validation with `whitelist`, `forbidNonWhitelisted`, and `transform`.
- Updated project create and update handling to map `content` to `readme` explicitly and regenerate the slug when the project name changes.
- Restricted user updates to allowed fields, handled missing users explicitly, and returned refreshed user data.
- Changed database logging to record query metadata instead of raw SQL.
- Denied direct `/api/metrics` access in both Nginx configurations.
- Refreshed backend and frontend lockfiles, including backend Nest/Express-related packages and frontend Next.js dependencies.

### Removed
- Removed the Nginx `/google-certs/` proxy and cache configuration in dev and prod.
- Removed the custom Google cert endpoint override from the Google auth service.

---

## Files Changed

| File | Change Type | Purpose |
|------|-------------|---------|
| `backend/package-lock.json` | modified | Refresh backend locked dependencies and transitive package versions. |
| `backend/src/auth/auth.controller.ts` | modified | Standardize auth responses and update logout cookie handling. |
| `backend/src/auth/auth.module.ts` | modified | Register and export auth-related guard wiring changes. |
| `backend/src/auth/auth.service.ts` | modified | Limit signup responses to selected user fields. |
| `backend/src/auth/googleAuth.service.ts` | modified | Remove custom cert URL handling and require verified Google emails. |
| `backend/src/auth/guards/auth.guard.ts` | modified | Clean up auth failure handling. |
| `backend/src/database/database.provider.ts` | modified | Log query metadata instead of raw SQL statements. |
| `backend/src/main.ts` | modified | Enable stricter global validation and payload transformation. |
| `backend/src/project/dtos/updateProject.dto.ts` | added | Validate partial project update payloads. |
| `backend/src/project/project.controller.ts` | modified | Apply the new update DTO to the update endpoint. |
| `backend/src/project/project.service.ts` | modified | Map project fields explicitly and rebuild slugs on name changes. |
| `backend/src/user/users.service.ts` | modified | Restrict editable fields and return refreshed user data. |
| `frontend/package-lock.json` | modified | Refresh frontend locked dependencies. |
| `infra/nginx.dev.conf` | modified | Remove Google cert proxying and deny `/api/metrics`. |
| `infra/nginx.prod.conf` | modified | Remove Google cert proxying and deny `/api/metrics`. |